### PR TITLE
fix(server): bind to localhost by default

### DIFF
--- a/whisper_server.py
+++ b/whisper_server.py
@@ -118,8 +118,8 @@ def main():
                         help=f"Compute type: auto, float16, int8 (default: {DEFAULT_COMPUTE})")
     parser.add_argument("--port", "-p", type=int, default=8002,
                         help="Port to run on (default: 8002)")
-    parser.add_argument("--host", default="0.0.0.0",
-                        help="Host to bind to (default: 0.0.0.0)")
+    parser.add_argument("--host", default="127.0.0.1",
+                        help="Host to bind to (default: 127.0.0.1)")
     args = parser.parse_args()
 
     # Update defaults from args


### PR DESCRIPTION
## Summary
- Change `whisper_server.py` default `--host` from `0.0.0.0` to `127.0.0.1`
- Prevents the unauthenticated Whisper server from being exposed to the entire local network
- Users who need network access can still pass `--host 0.0.0.0` explicitly

## Test plan
- [ ] Run `python whisper_server.py` and confirm it binds to `127.0.0.1:8002`
- [ ] Verify `--host 0.0.0.0` still works when explicitly passed